### PR TITLE
KEYVALUE-5 : Restful

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.wisc.my</groupId>
     <artifactId>key-value-store</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <parent>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/edu/wisc/my/keyvalue/model/KeyValue.java
+++ b/src/main/java/edu/wisc/my/keyvalue/model/KeyValue.java
@@ -6,6 +6,12 @@ import javax.persistence.Id;
 
 @Entity
 public class KeyValue{
+  
+    public KeyValue() {}
+    
+    public KeyValue(String key) {
+      this.key = key;
+    }
     
     @Id
     private String key;

--- a/src/main/java/edu/wisc/my/keyvalue/repository/KeyValueRepository.java
+++ b/src/main/java/edu/wisc/my/keyvalue/repository/KeyValueRepository.java
@@ -11,4 +11,6 @@ public interface KeyValueRepository extends Repository<KeyValue, Long>{
     
     public KeyValue save(KeyValue keyValue);
     
+    public KeyValue delete(KeyValue Key);
+    
 }

--- a/src/main/java/edu/wisc/my/keyvalue/service/IKeyValueService.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/IKeyValueService.java
@@ -22,4 +22,6 @@ public interface IKeyValueService{
      */
     public String setValue(String username, String key, String value);
     
+    public void delete(String username, String key);
+    
 }

--- a/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
@@ -30,5 +30,10 @@ public class KeyValueServiceImpl implements IKeyValueService{
         keyValueRepository.save(keyValue);
         return "Saved?";
     }
+
+    @Override
+    public void delete(String username, String key) {
+      keyValueRepository.delete(new KeyValue(username+":"+key));
+    }
     
 }


### PR DESCRIPTION
- Using [this](https://en.wikipedia.org/wiki/Representational_state_transfer), I changed the methods a bit.
  
  `/<key> GET` gets the key value object.
  `/<key> PUT` puts the value (still the request body, but you only have to pass in the value)
  `/<key> DELETE` deletes the row
- Upped the major version as this is API breakage.
- Also added some checking for the username
- Change storage so it just stores the raw request body if it is valid JSON. Makes the request easier to write. Instead of building a {value:"JSON.toString()"} object.
- Add in JSON validation on `PUT`
