### PR TITLE
Add ability of global settings, and user based sub directories

### DIFF
--- a/src/main/java/edu/wisc/my/keyvalue/controller/KeyValueStoreController.java
+++ b/src/main/java/edu/wisc/my/keyvalue/controller/KeyValueStoreController.java
@@ -1,10 +1,6 @@
 package edu.wisc.my.keyvalue.controller;
 
-import java.io.IOException;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import edu.wisc.my.keyvalue.service.IKeyValueService;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,14 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
-import edu.wisc.my.keyvalue.service.IKeyValueService;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 
 @Controller
@@ -43,11 +36,6 @@ public class KeyValueStoreController{
         this.keyValueService = keyValueService;
     }
 
-    @Value("${usernameAttribute}")
-    public void setUsernameAttr(String attr) {
-      usernameAttribute = attr;
-    }
-
     /**
      * Status page
      * @param response the thing to write to
@@ -67,122 +55,74 @@ public class KeyValueStoreController{
     }
 
     @RequestMapping(value="/{scope}/{key}", method=RequestMethod.PUT)
-    public @ResponseBody void putScopedKeyValue(HttpServletRequest request, HttpServletResponse response, @PathVariable String scope, @PathVariable String key, @RequestBody String valueJson) throws IOException {
-      String byUser = env.getRequiredProperty("scope." + scope + ".byUser");
-      boolean scopeUserBased = Boolean.parseBoolean(byUser);
-      logger.trace("scope {} byUser? {} : {}.", scope, byUser, scopeUserBased);
+    public @ResponseBody void putScopedKeyValue(HttpServletRequest request,
+                                                HttpServletResponse response,
+                                                @PathVariable String scope,
+                                                @PathVariable String key,
+                                                @RequestBody String valueJson) throws IOException {
+        putInternal(request, response, scope, key, valueJson);
+    }
 
-      String username = request.getHeader(usernameAttribute);
+    @RequestMapping(value="/{key}", method=RequestMethod.PUT)
+    public @ResponseBody void setKeyValue(HttpServletRequest request, HttpServletResponse response, @PathVariable String key, @RequestBody String valueJson){
+        putInternal(request, response, null, key, valueJson);
+    }
 
-      String prefix = scope;
-      boolean authorized = false;
-
-      if(!scopeUserBased) {
-        //we are editing a global scoped thing, so we must be an admin
-        String adminGroup = env.getRequiredProperty("scope." + scope + ".admin.group");
-        String groupHeader = env.getRequiredProperty("groupHeaderAttribute");
-
-        String header = request.getHeader(groupHeader);
-
-        authorized = header !=null && header.contains(adminGroup);
-      } else {
-        //a user is PUTing on a scoped key that is per attribute
-        String prefixAttr = env.getRequiredProperty("scope." + scope + ".prefixAttribute");
-        String filterHeaderValue = request.getHeader(prefixAttr);
-        authorized = filterHeaderValue != null;
-        prefix += ":" + filterHeaderValue;
-      }
-
-      if(authorized) {
-        //security check success
-
-        if(!isJSONValid(valueJson)) {
-          logger.error("Invalid request, json not valid");
-          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-          return;
+    private void putInternal(HttpServletRequest request, HttpServletResponse response, String scope, String key,  String value) {
+        //validation of request
+        if(!isJSONValid(value)) {
+            logger.error("Invalid request, json not valid");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
         }
 
-        logger.trace("Setting prefix: " + prefix + " key: " + key);
-        keyValueService.setValue(prefix, key, valueJson);
-
-        // write response
+        //save
         try {
-          response.getWriter().write(valueJson);
-          response.setContentType("application/json");
-          response.setStatus(HttpServletResponse.SC_OK);
-        } catch (IOException e) {
-          logger.error("Issues happened while trying to write json", e);
-          response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            keyValueService.setValue(request, scope, key, value);
+            //write response
+            writeResponse(response, value);
+        } catch(SecurityException se) {
+            logger.error("Access denied", se);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         }
-
-        logger.info("user " + username + " wrote to scope " + scope + " and key " + key + " with value " + valueJson);
-      } else {
-        logger.error("User " + username + " attempted to PUT to " + scope + " but doesn't have access, shame!");
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-      }
-
     }
 
     @RequestMapping(value="/{scope}/{key}", method=RequestMethod.GET)
-    public @ResponseBody void getScopedKeyValue(HttpServletRequest request, HttpServletResponse response, @PathVariable String scope, @PathVariable String key) throws IOException {
-      boolean scopeUserBased = Boolean.parseBoolean(env.getRequiredProperty("scope." + scope + ".byUser"));
-
-      if(scopeUserBased) {
-        String property = env.getProperty("scope." + scope + ".prefixAttribute");
-        String propHeaderValue = request.getHeader(property);
-        if(propHeaderValue != null) {
-          scope += ":" + propHeaderValue;
-        } else {
-          //there was a property for this scope, but the proper header was not set
-          logger.error(ACCESS_ERROR);
-          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-          return;
-        }
-      } else {
-        logger.trace("global hit");
-      }
-      logger.trace("Searching for prefix " + scope + " key: " + key);
-      String value = keyValueService.getValue(scope, key);
-      try {
-          if(isJSONValid(value)) {
-            logger.trace("Got something for scope : " + scope + ", key : " + key + ", value : " + value);
-            //valid json, cool, write it
-            response.getWriter().write(value);
-            response.setContentType("application/json");
-            response.setStatus(HttpServletResponse.SC_OK);
-          }
-          else {
-            logger.trace("Got nothing for scope : " + scope + ", key : " + key);
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-          }
-
-      } catch (IOException e) {
-          logger.error("Issues happened while trying to write json", e);
-          response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-      }
-
+    public @ResponseBody void getScopedKeyValue(HttpServletRequest request,
+                                                HttpServletResponse response,
+                                                @PathVariable String scope,
+                                                @PathVariable String key) throws IOException {
+      getInternal(request, response, scope, key);
     }
 
     @RequestMapping(value="/{key}", method=RequestMethod.GET)
     public @ResponseBody void getKeyValue(HttpServletRequest request, HttpServletResponse response, @PathVariable String key){
-        String username = request.getHeader(usernameAttribute);
-        if(username == null) {
-          logger.error(ACCESS_ERROR);
-          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-          return;
-        }
-        String value = keyValueService.getValue(username, key);
+        getInternal(request, response, null, key);
+    }
+
+    private void getInternal(HttpServletRequest request,
+                             HttpServletResponse response,
+                             String scope,
+                             String key) {
         try {
-            if(isJSONValid(value)) {
-              //valid json, cool, write it
-              response.getWriter().write(value);
+            String value = keyValueService.getValue(request, scope, key);
+            if (isJSONValid(value)) {
+                logger.trace("Got something for scope : {}, key : {}, value : {}", scope, key, value);
+                //valid json, cool, write it
+                writeResponse(response, value);
+            } else {
+                logger.trace("Got nothing for scope : {}, key : {}", scope, key);
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             }
-            else {
-              //if its not valid JSON (backwards compatible, wrap in a value object
-              JSONObject responseObj = new JSONObject();
-              responseObj.put("value", value);
-              response.getWriter().write(responseObj.toString());
-            }
+        } catch (SecurityException se) {
+            logger.error("Access denied", se);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        }
+    }
+
+    private void writeResponse(HttpServletResponse response, String json) {
+        try {
+            response.getWriter().write(json);
             response.setContentType("application/json");
             response.setStatus(HttpServletResponse.SC_OK);
         } catch (IOException e) {
@@ -191,42 +131,27 @@ public class KeyValueStoreController{
         }
     }
 
-    @RequestMapping(value="/{key}", method=RequestMethod.PUT)
-    public @ResponseBody void setKeyValue(HttpServletRequest request, HttpServletResponse response, @PathVariable String key, @RequestBody String valueJson){
-        //security check
-        String username = request.getHeader(usernameAttribute);
-        if(username == null) {
-          logger.error(ACCESS_ERROR);
-          response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-          return;
-        }
-
-        //validation of request
-        if(!isJSONValid(valueJson)) {
-          logger.error("Invalid request, json not valid");
-          response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-          return;
-        }
-
-        //save
-        keyValueService.setValue(username, key, valueJson);
-
-        //write response
-        try {
-          response.getWriter().write(valueJson);
-          response.setContentType("application/json");
-          response.setStatus(HttpServletResponse.SC_OK);
-        } catch (IOException e) {
-          logger.error("Issues happened while trying to write json", e);
-          response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        }
-    }
-
     @RequestMapping(value="/{key}", method=RequestMethod.DELETE)
     public @ResponseBody void delete(HttpServletRequest request, HttpServletResponse response, @PathVariable String key){
-        String username = request.getHeader(usernameAttribute);
-        keyValueService.delete(username, key);
-        response.setStatus(HttpServletResponse.SC_OK);
+        internalDelete(request, response, null, key);
+    }
+
+    @RequestMapping(value="/{scope}/{key}", method=RequestMethod.DELETE)
+    public @ResponseBody void deleteScoped(HttpServletRequest request,
+                                           HttpServletResponse response,
+                                           @PathVariable String scope,
+                                           @PathVariable String key){
+        internalDelete(request, response, scope, key);
+    }
+
+    private void internalDelete(HttpServletRequest request, HttpServletResponse response, String scope, String key) {
+        try {
+            keyValueService.delete(request, scope, key);
+            response.setStatus(HttpServletResponse.SC_OK);
+        } catch(SecurityException se) {
+            logger.error("Access denied", se);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        }
     }
 
     private boolean isJSONValid(String test) {

--- a/src/main/java/edu/wisc/my/keyvalue/controller/KeyValueStoreController.java
+++ b/src/main/java/edu/wisc/my/keyvalue/controller/KeyValueStoreController.java
@@ -70,7 +70,7 @@ public class KeyValueStoreController{
     public @ResponseBody void putScopedKeyValue(HttpServletRequest request, HttpServletResponse response, @PathVariable String scope, @PathVariable String key, @RequestBody String valueJson) throws IOException {
       String byUser = env.getRequiredProperty("scope." + scope + ".byUser");
       boolean scopeUserBased = Boolean.parseBoolean(byUser);
-      logger.trace("scope " + scope + " byUser? " +byUser + " : " + scopeUserBased);
+      logger.trace("scope {} byUser? {} : {}.", scope, byUser, scopeUserBased);
 
       String username = request.getHeader(usernameAttribute);
 

--- a/src/main/java/edu/wisc/my/keyvalue/model/KeyValue.java
+++ b/src/main/java/edu/wisc/my/keyvalue/model/KeyValue.java
@@ -1,7 +1,9 @@
 package edu.wisc.my.keyvalue.model;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 
 
 @Entity
@@ -16,6 +18,8 @@ public class KeyValue{
     @Id
     private String key;
     
+    @Lob
+    @Column(length=6000)
     private String value;
 
     public String getKey() {

--- a/src/main/java/edu/wisc/my/keyvalue/service/IKeyValueService.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/IKeyValueService.java
@@ -6,12 +6,12 @@ import org.springframework.stereotype.Service;
 public interface IKeyValueService{
 
     /**
-     * Returns the value for a given key and username
-     * @param username
+     * Returns the value for a given key and prefix
+     * @param prefix
      * @param key
      * @return may return empty string if nothing exists
      */
-    public String getValue(String username, String key);
+    public String getValue(String prefix, String key);
     
     /**
      * 
@@ -20,8 +20,8 @@ public interface IKeyValueService{
      * @param value
      * @return
      */
-    public String setValue(String username, String key, String value);
+    public String setValue(String prefix, String key, String value);
     
-    public void delete(String username, String key);
+    public void delete(String prefix, String key);
     
 }

--- a/src/main/java/edu/wisc/my/keyvalue/service/IKeyValueService.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/IKeyValueService.java
@@ -2,26 +2,56 @@ package edu.wisc.my.keyvalue.service;
 
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletRequest;
+
 @Service
-public interface IKeyValueService{
+public interface IKeyValueService {
+
+    public enum METHOD {
+        PUT,
+        GET,
+        DELETE
+    }
 
     /**
      * Returns the value for a given key and prefix
-     * @param prefix
+     * @param request
+     * @param scope
      * @param key
      * @return may return empty string if nothing exists
      */
-    public String getValue(String prefix, String key);
+    public String getValue(HttpServletRequest request, String scope, String key);
     
     /**
      * 
-     * @param username
+
      * @param key
      * @param value
      * @return
      */
-    public String setValue(String prefix, String key, String value);
-    
-    public void delete(String prefix, String key);
+    public void setValue(HttpServletRequest request, String scope, String key, String value);
+
+    /**
+     * Deletes a given key with prefix
+     * @param request
+     * @param scope
+     * @param key
+     */
+    public void delete(HttpServletRequest request, String scope, String key);
+
+    /**
+     *
+     * @param scope
+     * @return
+     */
+    boolean isByUser(String scope);
+
+    /**
+     *
+     * @param scope
+     * @param request
+     * @return
+     */
+    public boolean isAuthorized(String scope, HttpServletRequest request, METHOD method);
     
 }

--- a/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
@@ -1,15 +1,32 @@
 package edu.wisc.my.keyvalue.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 import edu.wisc.my.keyvalue.model.KeyValue;
 import edu.wisc.my.keyvalue.repository.KeyValueRepository;
 
+import javax.servlet.http.HttpServletRequest;
+
 @Service
-public class KeyValueServiceImpl implements IKeyValueService{
+public class KeyValueServiceImpl implements IKeyValueService {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
     
     private KeyValueRepository keyValueRepository;
+    private String usernameAttribute;
+
+    @Value("${usernameAttribute}")
+    public void setUsernameAttr(String attr) {
+        usernameAttribute = attr;
+    }
+
+    @Autowired
+    private Environment env;
     
     @Autowired
     public void setKeyValueRepository(KeyValueRepository keyValueRepository){
@@ -17,23 +34,69 @@ public class KeyValueServiceImpl implements IKeyValueService{
     }
 
     @Override
-    public String getValue(String prefix, String key) {
-        KeyValue keyValue = keyValueRepository.findByKey(prefix+":"+key);
-        return keyValue!=null ? keyValue.getValue() : "";
+    public String getValue(HttpServletRequest request, String scope, String key) {
+        if(isAuthorized(scope, request, METHOD.GET)) {
+            KeyValue keyValue = keyValueRepository.findByKey(getPrefix(request, scope) + ":" + key);
+            return keyValue != null ? keyValue.getValue() : "";
+        } else {
+            throw new SecurityException();
+        }
     }
 
     @Override
-    public String setValue(String prefix, String key, String value) {
-        KeyValue keyValue = new KeyValue();
-        keyValue.setKey(prefix+":"+key);
-        keyValue.setValue(value);
-        keyValueRepository.save(keyValue);
-        return "Saved?";
+    public void setValue(HttpServletRequest request, String scope, String key, String value) {
+        if(isAuthorized(scope, request, METHOD.PUT)){
+            KeyValue keyValue = new KeyValue();
+            keyValue.setKey(getPrefix(request, scope)+":"+key);
+            keyValue.setValue(value);
+            keyValueRepository.save(keyValue);
+        } else {
+            throw new SecurityException();
+        }
     }
 
     @Override
-    public void delete(String prefix, String key) {
-      keyValueRepository.delete(new KeyValue(prefix+":"+key));
+    public void delete(HttpServletRequest request, String scope, String key) {
+        if(isAuthorized(scope, request, METHOD.DELETE)){
+            keyValueRepository.delete(new KeyValue(getPrefix(request, scope)+":"+key));
+        } else {
+            throw new SecurityException();
+        }
     }
-    
+
+    @Override
+    public boolean isByUser(String scope){
+        String byUserString = env.getRequiredProperty("scope." + scope + ".byUser");
+        logger.trace("scope {} byUser? {}.", scope, byUserString);
+        return byUserString != null && Boolean.parseBoolean(byUserString);
+    }
+
+    @Override
+    public boolean isAuthorized(String scope, HttpServletRequest request, METHOD method) {
+        if(request.getHeader(usernameAttribute) == null) {
+
+            return false;
+        }
+
+        if(isByUser(scope)){
+            String prefixAttr = env.getRequiredProperty("scope." + scope + ".prefixAttribute");
+            String filterHeaderValue = request.getHeader(prefixAttr);
+            return filterHeaderValue != null;
+        }
+        else if(!METHOD.GET.equals(method)) {//global, and method != GET
+
+            String adminGroup = env.getRequiredProperty("scope." + scope + ".admin.group");
+            String groupHeader = env.getRequiredProperty("groupHeaderAttribute");
+            String groups = request.getHeader(groupHeader);
+            return groups !=null && groups.contains(adminGroup);
+        } else {
+            //global hit on a GET method
+            return true;
+        }
+    }
+
+    private String getPrefix (HttpServletRequest request, String scope) {
+        return isByUser(scope) ? scope + request.getHeader(usernameAttribute) : scope;
+    }
+
 }

--- a/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
@@ -17,23 +17,23 @@ public class KeyValueServiceImpl implements IKeyValueService{
     }
 
     @Override
-    public String getValue(String username, String key) {
-        KeyValue keyValue = keyValueRepository.findByKey(username+":"+key);
+    public String getValue(String prefix, String key) {
+        KeyValue keyValue = keyValueRepository.findByKey(prefix+":"+key);
         return keyValue!=null ? keyValue.getValue() : "";
     }
 
     @Override
-    public String setValue(String username, String key, String value) {
+    public String setValue(String prefix, String key, String value) {
         KeyValue keyValue = new KeyValue();
-        keyValue.setKey(username+":"+key);
+        keyValue.setKey(prefix+":"+key);
         keyValue.setValue(value);
         keyValueRepository.save(keyValue);
         return "Saved?";
     }
 
     @Override
-    public void delete(String username, String key) {
-      keyValueRepository.delete(new KeyValue(username+":"+key));
+    public void delete(String prefix, String key) {
+      keyValueRepository.delete(new KeyValue(prefix+":"+key));
     }
     
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,9 @@ spring.jpa.hibernate.ddl-auto=create
 # Application Properties
 # Attribute read for user name saving
 usernameAttribute=uid
+
+# Scopes
+# key is scope.{scope}
+# value is the required attribute that needs to be populated as a header, blank means free to anyone
+scope.global=
+scope.myuw=uid

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,8 +12,12 @@ spring.jpa.hibernate.ddl-auto=create
 # Attribute read for user name saving
 usernameAttribute=uid
 
-# Scopes
-# key is scope.{scope}
-# value is the required attribute that needs to be populated as a header, blank means free to anyone
-scope.global=
-scope.myuw=uid
+groupHeaderAttribute=ismemberof
+
+# Global scope, same values for everyone
+scope.global.byUser=false
+scope.global.admin.group=uw:domain:my.wisc.edu:my_uw_administrators
+
+# MyUW Scope, per user scoped
+scope.myuw.prefixAttribute=uid
+scope.myuw.byUser=true

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -53,7 +53,7 @@
       <appender-ref ref="LOG"/>
   </root>
 
-  <logger name="edu.wisc" additivity="false" level="DEBUG">
+  <logger name="edu.wisc" additivity="false" level="TRACE">
       <appender-ref ref="LOG"/>
   </logger>
 </configuration>


### PR DESCRIPTION
Adds 
- `/{scope}/{key}` GET
- `/{scope}/{key}` PUT

scope is something setup in `application.properties`. There can be many, e.g.: myuw, global, profile

key is the key.

Scopes can be global for everyone, or have an attribute that divides them. 

If the scope is byAttribute it is stored like `scope:attribute:key` as the key.

If the scope is global it is stored like `scope:key` as the key.

The value is still JSON.

Note this also changes the value storage to a LOB with max length of 6000 characters.
### UPDATE NOTES

To update this for oracle, run the following script:

```
alter table key_value add (temp clob);
update key_value set temp = value
alter table key_value drop column value;
alter table key_value rename column temp to value;
```
