### PR TITLE
Add Dependency Status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Key Value Store
 
 [![Build Status](https://travis-ci.org/UW-Madison-DoIT/KeyValueStore.svg)](https://travis-ci.org/UW-Madison-DoIT/KeyValueStore)
+[![Dependency Status](https://dependencyci.com/github/UW-Madison-DoIT/KeyValueStore/badge)](https://dependencyci.com/github/UW-Madison-DoIT/KeyValueStore)
 
 A separate service to enable key value storage for MyUW applications
 


### PR DESCRIPTION
Adds a reassuring badge about the goodness of the project's dependencies, thereby documenting that dependencyci.com continually checks dependencies of this product.