### PR TITLE
KEYVALUE-11 Copes with no/blank UID present in header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
 
     <dependencies>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.6</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
       </dependency>

--- a/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.keyvalue.service;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,7 +81,7 @@ public class KeyValueServiceImpl implements IKeyValueService {
 
     @Override
     public boolean isAuthorized(String scope, HttpServletRequest request, METHOD method) {
-        if(request.getHeader(usernameAttribute) == null) {
+        if(StringUtils.isBlank(request.getHeader(usernameAttribute))) {
             return false;
         }
 

--- a/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
+++ b/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
@@ -60,6 +60,32 @@ class KeyValueServiceTest {
     String response = keyValueService.getValue(request, "global", "someKey");
     assertEquals(ret.getValue(), response);
   }
+  
+  @Test(expected=SecurityException.class)
+  void test_no_user_name_in_header_get(){ 
+    MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.toString(), "")
+    keyValueService.getValue(request, "global", "someKey")
+  }
+  
+  @Test(expected=SecurityException.class)
+  void test_blank_user_name_in_header_get(){ 
+    MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.toString(), "")
+    request.addHeader("uid", "  ")
+    keyValueService.getValue(request, "global", "someKey")
+  }
+  
+    @Test(expected=SecurityException.class)
+  void test_no_user_name_in_header_put(){ 
+    MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.PUT.toString(), "")
+    keyValueService.getValue(request, "global", "someKey")
+  }
+  
+  @Test(expected=SecurityException.class)
+  void test_blank_user_name_in_header_put(){ 
+    MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.PUT.toString(), "")
+    request.addHeader("uid", "  ")
+    keyValueService.getValue(request, "global", "someKey")
+  }
 
   @Test(expected=SecurityException.class)
   void test_global_put_invalid() {


### PR DESCRIPTION
Adds a check for blank user name.  