### PR TITLE
Support for multiple user id attributes

### DIFF
--- a/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
@@ -21,42 +21,19 @@ public class KeyValueServiceImpl implements IKeyValueService {
     private KeyValueRepository keyValueRepository;
     private Environment env;
     private String usernameAttribute;
-    private String additionalAttributes;
-    private String[] allAttributes;
+     private String[] allAttributes;
 
     @Value("${usernameAttribute}")
     public void setUsernameAttr(String attr) {
         usernameAttribute = attr;
-    }
-
-    @Value("${additionalAttributes}")
-    public void setAdditionalAttributes(String attr) {
-        //Additional attributes are stored in a comma delimited string.
-        //If additional attributes are present, this method constructs an array with the usernameAttr as the first element,
-        // and additional elements following in order. 
-
-        //If no additional elements are present, this method will constuct a one-element array 
-        //consisting of the usernameAttr.
-        if(StringUtils.isNotBlank(attr)){
-            additionalAttributes = attr;
-            String[] tempArray = additionalAttributes.split(",");
-            allAttributes = new String[tempArray.length +1];
-            allAttributes[0] = usernameAttribute;
-            for(int x=1;x<tempArray.length+1;x++){
-                allAttributes[x] = tempArray[x-1].trim();
-            }
-        }else{
-            allAttributes = new String[1];
-            allAttributes[0] = usernameAttribute;
+        String[] tempArray = usernameAttribute.split(",");
+        allAttributes = new String[tempArray.length];
+        for(int x=0;x<tempArray.length;x++){
+          allAttributes[x] = tempArray[x].trim();
         }
     }
 
     private String[] getAllAttributes(){
-        if(this.allAttributes==null){
-            this.allAttributes=new String[1];
-            this.allAttributes[0]=usernameAttribute;
-        }
-
         return this.allAttributes;
     }
 
@@ -66,7 +43,6 @@ public class KeyValueServiceImpl implements IKeyValueService {
                 return attribute;
             }
         }
-
         return null;
     }
 

--- a/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
+++ b/src/main/java/edu/wisc/my/keyvalue/service/KeyValueServiceImpl.java
@@ -43,14 +43,11 @@ public class KeyValueServiceImpl implements IKeyValueService {
             allAttributes = new String[tempArray.length +1];
             allAttributes[0] = usernameAttribute;
             for(int x=1;x<tempArray.length+1;x++){
-                allAttributes[x] = tempArray[x-1];
+                allAttributes[x] = tempArray[x-1].trim();
             }
         }else{
             allAttributes = new String[1];
             allAttributes[0] = usernameAttribute;
-        }
-        for(String at:allAttributes){
-            logger.trace("Attribute  = " + at);
         }
     }
 
@@ -65,7 +62,6 @@ public class KeyValueServiceImpl implements IKeyValueService {
 
     private String getAttribute(HttpServletRequest request){
         for(String attribute:getAllAttributes()){
-            logger.trace(attribute);
             if(StringUtils.isNotBlank(request.getHeader(attribute))){
                 return attribute;
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,8 +10,9 @@ spring.jpa.hibernate.ddl-auto=create
 
 # Application Properties
 # Attribute read for user name saving
-usernameAttribute=dummy
-additionalAttributes=sysid,tertiary
+usernameAttribute=uid
+# Optional comma delimited list of additional attributes to be used in user name saving
+#additionalAttributes=secondary,tertiary
 
 
 groupHeaderAttribute=ismemberof

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,9 @@ spring.jpa.hibernate.ddl-auto=create
 
 # Application Properties
 # Attribute read for user name saving
-usernameAttribute=uid
+usernameAttribute=dummy
+additionalAttributes=sysid,tertiary
+
 
 groupHeaderAttribute=ismemberof
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,10 +10,9 @@ spring.jpa.hibernate.ddl-auto=create
 
 # Application Properties
 # Attribute read for user name saving
+# Optionally, usernameAttribute can be a comma-delimited list of attributes.
+# e.g. usernameAttribute=uid,secondary,tertiary
 usernameAttribute=uid
-# Optional comma delimited list of additional attributes to be used in user name saving
-#additionalAttributes=secondary,tertiary
-
 
 groupHeaderAttribute=ismemberof
 

--- a/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
+++ b/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
@@ -24,9 +24,7 @@ import static org.junit.Assert.assertEquals
 
 @RunWith(MockitoJUnitRunner.class)
 class KeyValueServiceTest {
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
-
-
+ 
   @InjectMocks KeyValueServiceImpl keyValueService = new KeyValueServiceImpl();
 
   @Mock KeyValueRepository keyValueRepository;

--- a/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
+++ b/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
@@ -22,8 +22,13 @@ import static org.mockito.Mockito.when
 import static org.mockito.Mockito.any
 import static org.junit.Assert.assertEquals
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 @RunWith(MockitoJUnitRunner.class)
 class KeyValueServiceTest {
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+
 
   @InjectMocks KeyValueServiceImpl keyValueService = new KeyValueServiceImpl();
 
@@ -31,11 +36,13 @@ class KeyValueServiceTest {
   private MockEnvironment env = new MockEnvironment();
 
   final String usernameAttribute = "uid";
+  final String additionalAttributes = "sysid,dummy,tertiary";
 
   @Before()
   void setup() {
 
     env.setProperty("usernameAttribute","uid");
+    env.setProperty("additionalAttributes","sysid,dummy,tertiary");
     env.setProperty("groupHeaderAttribute", "ismemberof");
 
     env.setProperty("scope.global.byUser", "false");
@@ -46,8 +53,11 @@ class KeyValueServiceTest {
 
     keyValueService.setKeyValueRepository(keyValueRepository);
     keyValueService.setUsernameAttr(usernameAttribute);
+    keyValueService.setAdditionalAttributes(additionalAttributes);
     keyValueService.setEnv(env);
   }
+
+
 
   @Test
   void test_global_get_valid() {
@@ -96,6 +106,22 @@ class KeyValueServiceTest {
 
     keyValueService.setValue(request, scope, key, value);
     fail("Should not get here")
+  }
+
+  @Test
+  void test_additional_attributes(){
+    keyValueService.setUsernameAttr("NONE");
+      MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.toString(), "")
+    request.addHeader("dummy", "reed")
+    keyValueService.getValue(request, "global", "someKey")
+  }
+
+    @Test
+  void test_null_additional_attributes(){
+    keyValueService.setAdditionalAttributes(null);
+    MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.toString(), "")
+    request.addHeader("uid", "reed")
+    keyValueService.getValue(request, "global", "someKey")
   }
 
   @Test()

--- a/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
+++ b/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
@@ -31,13 +31,11 @@ class KeyValueServiceTest {
   private MockEnvironment env = new MockEnvironment();
 
   final String usernameAttribute = "uid";
-  final String additionalAttributes = "sysid,dummy,tertiary";
 
   @Before()
   void setup() {
 
     env.setProperty("usernameAttribute","uid");
-    env.setProperty("additionalAttributes","sysid,dummy,tertiary");
     env.setProperty("groupHeaderAttribute", "ismemberof");
 
     env.setProperty("scope.global.byUser", "false");
@@ -48,7 +46,6 @@ class KeyValueServiceTest {
 
     keyValueService.setKeyValueRepository(keyValueRepository);
     keyValueService.setUsernameAttr(usernameAttribute);
-    keyValueService.setAdditionalAttributes(additionalAttributes);
     keyValueService.setEnv(env);
   }
 
@@ -105,17 +102,9 @@ class KeyValueServiceTest {
 
   @Test
   void test_additional_attributes(){
-    keyValueService.setUsernameAttr("NONE");
-      MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.toString(), "")
-    request.addHeader("dummy", "reed")
-    keyValueService.getValue(request, "global", "someKey")
-  }
-
-    @Test
-  void test_null_additional_attributes(){
-    keyValueService.setAdditionalAttributes(null);
+    keyValueService.setUsernameAttr("NONE, dummy");
     MockHttpServletRequest request = new MockHttpServletRequest(HttpMethod.GET.toString(), "")
-    request.addHeader("uid", "reed")
+    request.addHeader("dummy", "reed")
     keyValueService.getValue(request, "global", "someKey")
   }
 

--- a/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
+++ b/src/test/groovy/edu/wisc/my/keyvalue/service/KeyValueServiceTest.groovy
@@ -22,9 +22,6 @@ import static org.mockito.Mockito.when
 import static org.mockito.Mockito.any
 import static org.junit.Assert.assertEquals
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-
 @RunWith(MockitoJUnitRunner.class)
 class KeyValueServiceTest {
   protected final Logger logger = LoggerFactory.getLogger(getClass());


### PR DESCRIPTION
This pull request adds an optional comma delimited parameter to application.properties allowing multiple header attributes to be searched when assigning a user name to the user scoped key. If unutilized, KeyValueStore will behave as always with a single attribute parameter.