### PR TITLE
WIP: Document that KeyValueStore is a uw-frame sub-project implicitly incubating

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to `KeyValueStore`
+
+## Code of conduct
+
+The [Apereo Welcoming Policy][] applies. Cf. [CODE_OF_CONDUCT.md][]
+
+## Contributor License Agreements
+
+As a sub-project of an [incubating, aspiring Apereo product][AngularJS-portal website on incubating], `KeyValueStore` requires contributors and contributions to comply with [Apereo inbound intellectual property licensing practices][].
+
+The short version:
+
++ You must have submitted an [Apereo Individual Contributor License Agreement][]
++ You individually must actually appear in the [roster of registered ICLAs][Apereo CLA roster].
++ To the extent that you're working under the auspices of an employer or working on behalf of anyone or anything other than yourself individually, those entities must have submitted a [Apereo Corporate Contributor License Agreement][] naming you as an authorized contributor.
++ Those entities must actually appear in [the roster of registered CCLAs][Apereo CLA roster].
+
+The long version:
+
++ [Apereo website on licensing][]
++ [Apereo website on Contributor License Agreement][]
+
+*Please* provide feedback about how these practices impact your ability to contribute. You might voice that feedback on the [Apereo licensing discussion Google Group][] or in any other way in which you are comfortable.
+
+[AngularJS-portal website on incubating]: http://uw-madison-doit.github.io/angularjs-portal/apereo-incubation.html
+[Apereo inbound intellectual property licensing practices]: https://www.apereo.org/licensing/practices
+[Apereo Individual Contributor License Agreement]: https://www.apereo.org/sites/default/files/Licensing%20Agreements/apereo-icla.pdf
+[Apereo Corporate Contributor License Agreement]: https://www.apereo.org/sites/default/files/Licensing%20Agreements/apereo-ccla.pdf
+[Apereo website on licensing]: https://www.apereo.org/licensing
+[Apereo website on Contributor License Agreement]: https://www.apereo.org/licensing/agreements
+[Apereo licensing discussion Google Group]: https://groups.google.com/a/apereo.org/forum/#!forum/licensing-discuss
+[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
+[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
+[Apereo Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+{Substantive content goes here. Summarize the changeset and *why* the changeset.}
+
+----
+
+Contributor License Agreement adherence:
+
+<!-- Place an x in the checkbox for YES. -->
+
+- [ ] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].
+
+[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
+[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This is a uPortal Application Framework sub-project.
+
+It inherits the [Code of Conduct considerations of the uPortal Application Framework project][uPortal Application Framework Code of Conduct], which in turn inherits the [Code of Conduct considerations of the uPortal Ecosystem][uPortal Code of Conduct], which in turn participates in the [Apereo Welcoming Policy][].
+
+Be kind. Also be brave. But if you cannot be brave, at least be kind.
+
+[uPortal Application Framework Code of Conduct]: https://github.com/UW-Madison-DoIT/uw-frame/blob/master/CODE_OF_CONDUCT.md
+[uPortal Code of Conduct]: https://github.com/Jasig/uPortal/blob/master/CODE_OF_CONDUCT.md
+[Apereo Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy

--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,11 @@
+# Committers
+
+This is a sub-project of the [uPortal Application Framework][] project (which is in turn a sub-project of the [uPortal-home][] project, which in turn is [incubating][uPortal-home incubating] in the uPortal Ecosystem, which in turn is a sponsored project of the [Apereo Foundation][].)
+
+The [uPortal Application Framework Committers][] are the Committers for this repository.
+
+[uPortal Application Framework]: https://github.com/UW-Madison-DoIT/uw-frame
+[uPortal Application Framework Committers]: https://github.com/UW-Madison-DoIT/uw-frame/blob/master/committers.md
+[uPortal-home]: https://github.com/UW-Madison-DoIT/angularjs-portal
+[uPortal-home incubating]: http://uw-madison-doit.github.io/angularjs-portal/apereo-incubation.html
+[Apereo Foundation]: https://www.apereo.org/


### PR DESCRIPTION
This Pull Request is in part an experiment to see if we're on the same page about what `KeyValueStore` is and where we're going with it and how it relates to `uw-frame`.

The proximate cause is followup on Christian Murphy's election as a uPortal Application Framework committer and working through what all that implies.

States:

+ `KeyValueStore` is a sub-project of `uw-frame`, and so is Incubating.
+ The Committer roster for `KeyValueStore` is that of `uw-frame` ( @UW-Madison-DoIT/uportal-application-framework-committers ).
+ Apereo ICLA required to contribute
+ Apereo Welcoming Policy applies