### PR TITLE
Acknowledge unclear relationship with Apereo Welcoming Policy.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of conduct
+
+Be kind. Also be brave. But if you cannot be brave, at least be kind.
+
+This project aspires to be an organism in the [Apereo] [uPortal] ecosystem. Were this project formally in the context of uPortal, the [Apereo Welcoming Policy] would necessarily apply.
+
+It's not clear that this project is currently under the auspices of Apereo, so it's not presently clear that the Apereo Welcoming Policy applies.
+
+Please be kind in your participation in this project. If participants are unkind the maintainers will have to figure out what to do about it, and that's not likely to be much fun for anyone.
+
+[Apereo]: https://www.apereo.org/
+[uPortal]: https://www.apereo.org/projects/uportal
+[Apereo Welcoming Policy]: https://www.apereo.org/content/apereo-welcoming-policy


### PR DESCRIPTION
Not clear this is an "Apereo project" (cf. #18 ) so not clear the Welcoming Policy applies.

Acknowledge this reality. Participants should be clear-eyed on whether they can expect to rely upon the Apereo Welcoming Policy in cushioning any untoward interactions they might have in the context of this project.