### PR TITLE
Bootstrap committers

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -1,0 +1,12 @@
+# Committers
+
+This project aspires to be a free and open source software project in the uPortal ecosystem.
+
+For purposes of bootstrapping such a viable open source software project, the Committers are
+
++ Andrew Petro ( @apetro )
++ Doug Reed ( @Doug-Reed )
++ David Sibley ( @davidmsibley )
++ Tim Vertein ( @vertein )
+
+With progress towards bootstrapping this project into a collaborative open source software project context, we might be able to simplify the Committers definition on this project to a reference to Committers on a parent project.


### PR DESCRIPTION
#18 would define Committers for this project by reference to Committers for the `uw-frame` aka uPortal-application-framework project. I hope that's where this is eventually going.

But it's not presently entirely clear that this project is formally in that Apereo context. This changeset would make a more modest but more unambiguously achievable next step of bootstrapping a small Committers roster here. This isn't so useful on its own, but it'd be a step towards unblocking realizing the project as a viable open source project in that there'd be a stake in the ground, a starting point from which to iterate in defining the committers set and the formalisms of the project.