### PR TITLE
chore(gitignore): ignore Netbeans build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ build/
 target/
 bin/
 dependency-reduced-pom.xml
-
+META-INF/
 data
 
 
@@ -32,3 +32,6 @@ data
 *.ipr
 *.iws
 *.idea
+
+# Netbeans Files
+nb-configuration.xml


### PR DESCRIPTION
These files are autogenerated by Netbeans, and shouldn't be committed.

----

Contributor license agreement adherence:

<!-- Replace the single whitespace character in the square brackets with an x to check the box. -->

- [x] This Contribution is under the terms [Apereo Individual Contributor License Agreement]s (and also [Apereo Corporate Contributor License Agreement]s as necessary) appearing in the public [Apereo CLA signatory roster].

<!-- While it's not entirely clear that this project actually is under the auspices of Apereo at this time, the project aspires to participation in the Apereo uPortal ecosystem, and the less ICLA hunting down we'd have to do to make progress on that in the future the easier that's going to be, so please square away your ICLA signatory status now before contributing rather than leaving it for later. -->


[Apereo Individual Contributor License Agreement]: https://www.apereo.org/licensing/agreements/icla
[Apereo CLA signatory roster]: http://licensing.apereo.org/
[Apereo Corporate Contributor License Agreement]: https://www.apereo.org/licensing/agreements/ccla
