### PR TITLE
ci(travis): test using OpenJDK 8 and Oracle JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
-script :
-  - mvn package
 jdk:
-  - oraclejdk7
-sudo: false
+  - openjdk8
+  - oraclejdk8
+script: mvn package


### PR DESCRIPTION
Travis CI's new Ubuntu Trusty Environment has issues with JDK7, if it needs to be tested the precise environment should be used.

resolves #23

----

Contributor license agreement adherence:

<!-- Replace the single whitespace character in the square brackets with an x to check the box. -->

- [x] This Contribution is under the terms [Apereo Individual Contributor License Agreement]s (and also [Apereo Corporate Contributor License Agreement]s as necessary) appearing in the public [Apereo CLA signatory roster].

<!-- While it's not entirely clear that this project actually is under the auspices of Apereo at this time, the project aspires to participation in the Apereo uPortal ecosystem, and the less ICLA hunting down we'd have to do to make progress on that in the future the easier that's going to be, so please square away your ICLA signatory status now before contributing rather than leaving it for later. -->


[Apereo Individual Contributor License Agreement]: https://www.apereo.org/licensing/agreements/icla
[Apereo CLA signatory roster]: http://licensing.apereo.org/
[Apereo Corporate Contributor License Agreement]: https://www.apereo.org/licensing/agreements/ccla
